### PR TITLE
fix: usage_of_deprecated_method

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -65,7 +65,7 @@ class ParrotSkill(OVOSSkill):
         # replaces https://github.com/MatthewScholefield/skill-repeat-recent
         sess = SessionManager.get(message)
         if sess.session_id not in self.parrot_sessions:
-            utt = self.translate('nothing')
+            utt = self.resources.render_dialog('nothing')
         else:
             utt = self.parrot_sessions[sess.session_id]["prev_tts"]
 
@@ -76,7 +76,7 @@ class ParrotSkill(OVOSSkill):
         # replaces https://github.com/MatthewScholefield/skill-repeat-recent
         sess = SessionManager.get(message)
         if sess.session_id not in self.parrot_sessions:
-            utt = self.translate('nothing')
+            utt = self.resources.render_dialog('nothing')
             ts = 0
         else:
             utt = self.parrot_sessions[sess.session_id]["prev_stt"]


### PR DESCRIPTION
self.translate has been deprecated for a while and remove from ovos-workshop base class

similar to https://github.com/OpenVoiceOS/skill-ovos-date-time/issues/56